### PR TITLE
Do not mutate the final object after collecting the information

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,8 +123,8 @@ GeneratePackageJsonPlugin.prototype.apply = function(compiler) {
 
     logIfDebug(`GPJWP: Modules to be used in generated package.json`, modules);
 
-    Object.assign(this.otherPackageValues, { dependencies: orderKeys(modules) });
-    const json = JSON.stringify(this.otherPackageValues, this.replacer ? this.replacer : null, this.space ? this.space : 2);
+    const finalPackageValues = Object.assign({}, this.otherPackageValues, { dependencies: orderKeys(modules) });
+    const json = JSON.stringify(finalPackageValues, this.replacer ? this.replacer : null, this.space ? this.space : 2);
 
     compilation.assets['package.json'] = {
       source: function() {


### PR DESCRIPTION
Fixes problems with watching while using this plugin - since the object was mutated and persisted incorrect values between the watch build cycles.

Fixes #4 