### PR TITLE
Checking module exists in the original package.json before using it

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ GeneratePackageJsonPlugin.prototype.apply = function(compiler) {
       for (let k = 0; k < nonWebpackModuleNames.length; k += 1) {
         const moduleName = nonWebpackModuleNames[k];
 
-        if (this.otherPackageValues.dependencies[moduleName].length > 0) {
+        if (this.otherPackageValues.dependencies[moduleName] && this.otherPackageValues.dependencies[moduleName].length > 0) {
           logIfDebug(`GPJWP: Adding deliberate module with version set deliberately: ${moduleName} -> ${this.otherPackageValues.dependencies[moduleName]}`);
           modules[moduleName] = this.otherPackageValues.dependencies[moduleName];
         } else if (this.dependencyVersionMap[moduleName] != null) {


### PR DESCRIPTION
There are workflows where you cannot install bundle dependencies and project dependencies together.
In my case I have a single repo project in which I use 'firebase-admin' (for server-side code) and 'firebase' (for client-side code) but they cannot be installed together (There is a plethora of issues talking about this out there).

With this pr, I fixed an issue (`TypeError: Cannot read property 'length' of undefined`
 at line 114) when you try to define a package into the basePackageValues and not into the original package.json too.