### PR TITLE
Add suport for different dependency types

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ const basePackageValues = {
     "cross-var": "^1.1.0",
     "cross-env": "",
   },
+  peerDependencies: {
+    "react" : "",
+  }
 }
 ```
 
@@ -96,6 +99,10 @@ regardless of what is in `versionsPackageFilename` it will use this version.
 This is mostly useful for adding dependencies which are required at runtime but which are not picked up in your webpack
 bundle. Such as `cross-var` in this example which injects environment variables into a run script in a cross-platform
 friendly way.
+
+Note that the same behaviour applies to all types of dependencies (`dependencies`, `devDependencies` and 
+`peerDependencies`). In this example `react` will have the same behaviour as `cross-env`, but rather than being placed 
+inside the `dependencies` list in the output file, it will be placed inside the `peerDependencies` list.
 
 ## Simple API
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# Next
+
+* Add `peerDependencies` and `devDependencies` support
+
 # 1.1.1
 
 (Much thanks to @moshest for these changes)

--- a/index.js
+++ b/index.js
@@ -72,6 +72,8 @@ function getNameFromPortableId(raw) {
 
 GeneratePackageJsonPlugin.prototype.apply = function(compiler) {
   const hook = (compilation, callback) => {
+    const dependencyTypes = ["dependencies", "devDependencies", "peerDependencies"]
+
     const modules = Object.assign({}, this.additionalDependencies);
 
     const processModule = (module) => {
@@ -142,29 +144,45 @@ GeneratePackageJsonPlugin.prototype.apply = function(compiler) {
       }
     });
 
-    // Overwrite modules or set new module dependencies for those that have been
-    // deliberately set in " otherPackageValues.dependencies "
-    if (this.otherPackageValues && this.otherPackageValues.dependencies) {
-      const nonWebpackModuleNames = Object.keys(this.otherPackageValues.dependencies);
+    const basePackageValues = Object.assign({}, this.otherPackageValues);
 
-      for (let k = 0; k < nonWebpackModuleNames.length; k += 1) {
-        const moduleName = nonWebpackModuleNames[k];
+    for (let i = 0; i < dependencyTypes.length; i += 1) {
+      const dependencyType = dependencyTypes[i];
 
-        if (this.otherPackageValues.dependencies[moduleName] && this.otherPackageValues.dependencies[moduleName].length > 0) {
-          logIfDebug(`GPJWP: Adding deliberate module with version set deliberately: ${moduleName} -> ${this.otherPackageValues.dependencies[moduleName]}`);
-          modules[moduleName] = this.otherPackageValues.dependencies[moduleName];
-        } else if (this.dependencyVersionMap[moduleName] != null) {
-          logIfDebug(`GPJWP: Adding deliberate module with version found in sources: ${moduleName} -> ${this.dependencyVersionMap[moduleName]}`);
-          modules[moduleName] = this.dependencyVersionMap[moduleName];
-        } else {
-          console.warn(`GeneratePackageJsonPlugin: You have set a module to be included deliberately with name: "${moduleName}" - but there is no version specified in any source files!`);
+      // Overwrite modules or set new module dependencies for those that have been
+      // deliberately set in " basePackageValues.[dependencyType] "
+      // This mechanism ensures that dependencies declared in the basePackageValues
+      // take precedence over the found dependencies
+      if (basePackageValues && basePackageValues[dependencyType]) {
+        const nonWebpackModuleNames = Object.keys(basePackageValues[dependencyType]);
+
+        for (let k = 0; k < nonWebpackModuleNames.length; k += 1) {
+          const moduleName = nonWebpackModuleNames[k];
+
+          if (basePackageValues[dependencyType][moduleName] && basePackageValues[dependencyType][moduleName].length > 0) {
+            logIfDebug(`GPJWP: Adding deliberate module in "${dependencyType}" with version set deliberately: ${moduleName} -> ${basePackageValues[dependencyType][moduleName]}`);
+            if (dependencyType === "dependencies"){
+              modules[moduleName] = basePackageValues[dependencyType][moduleName];
+            }
+          } else if (this.dependencyVersionMap[moduleName] != null) {
+            logIfDebug(`GPJWP: Adding deliberate module in "${dependencyType}" with version found in sources: ${moduleName} -> ${this.dependencyVersionMap[moduleName]}`);
+            if (dependencyType !== "dependencies") {
+              basePackageValues[dependencyType][moduleName] = this.dependencyVersionMap[moduleName];
+              delete modules[moduleName];
+            }
+            else {
+              modules[moduleName] = this.dependencyVersionMap[moduleName];
+            }
+          } else {
+            console.warn(`GeneratePackageJsonPlugin: You have set a module in "${dependencyType}" to be included deliberately with name: "${moduleName}" - but there is no version specified in any source files!`);
+          }
         }
       }
     }
 
     logIfDebug(`GPJWP: Modules to be used in generated package.json`, modules);
 
-    const finalPackageValues = Object.assign({}, this.otherPackageValues, { dependencies: orderKeys(modules) });
+    const finalPackageValues = Object.assign({}, basePackageValues, { dependencies: orderKeys(modules) });
     const json = JSON.stringify(finalPackageValues, this.replacer ? this.replacer : null, this.space ? this.space : 2);
 
     compilation.assets['package.json'] = {

--- a/index.js
+++ b/index.js
@@ -146,8 +146,7 @@ GeneratePackageJsonPlugin.prototype.apply = function(compiler) {
 
     const basePackageValues = Object.assign({}, this.otherPackageValues);
 
-    for (let i = 0; i < dependencyTypes.length; i += 1) {
-      const dependencyType = dependencyTypes[i];
+    for (const dependencyType of dependencyTypes) {
 
       // Overwrite modules or set new module dependencies for those that have been
       // deliberately set in " basePackageValues.[dependencyType] "
@@ -159,7 +158,7 @@ GeneratePackageJsonPlugin.prototype.apply = function(compiler) {
         for (let k = 0; k < nonWebpackModuleNames.length; k += 1) {
           const moduleName = nonWebpackModuleNames[k];
 
-          if (basePackageValues[dependencyType][moduleName] && basePackageValues[dependencyType][moduleName].length > 0) {
+          if (basePackageValues[dependencyType] && basePackageValues[dependencyType][moduleName] && basePackageValues[dependencyType][moduleName].length > 0) {
             logIfDebug(`GPJWP: Adding deliberate module in "${dependencyType}" with version set deliberately: ${moduleName} -> ${basePackageValues[dependencyType][moduleName]}`);
             if (dependencyType === "dependencies"){
               modules[moduleName] = basePackageValues[dependencyType][moduleName];


### PR DESCRIPTION
Solves issue #20.

This has been tested on a large scale application (over 30 found dependencies on a successful build) and it works well with multiple cases (tested with `dependencies` and `peerDependencies`, with both their version numbers specified and unspecified).

With the current `dependencyTypes` mechanism in place, we can also easily add another dependency type such as `ignoredDependencies` if we wish to add that feature as well.