### PR TITLE
Fix export in TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,4 +16,4 @@ declare class GeneratePackageJsonPlugin extends Plugin {
   );
 }
 
-export default GeneratePackageJsonPlugin;
+export = GeneratePackageJsonPlugin;


### PR DESCRIPTION
This PR fixes the `export` declaration in the TS typings file to more closely reflect what the JS code is doing and to allow use in TypeScript regardless of the `esModuleInterop` setting.