### PR TITLE
check all modules or webpack5, independent from chunks

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,26 +178,28 @@ GeneratePackageJsonPlugin.prototype.apply = function (compiler) {
       modules[moduleName] = version;*/
     };
 
-    compilation.chunks.forEach((chunk) => {
-      if (isWebpack5) {
-        for (const module of compilation.chunkGraph.getChunkModulesIterable(chunk)) {
-          processModule(module);
-        }
-      } else if (typeof chunk.modulesIterable !== "undefined") { // webpack 4
-        for (const module of chunk.modulesIterable) {
-          processModule(module);
-        }
-      } else if (typeof chunk.forEachModule !== "undefined") { // webpack 3
-        chunk.forEachModule((module) => {
-          processModule(module);
-        });
-      } else { // webpack 2
-        for (let i = 0; i < chunk.modules.length; i += 1) {
-          const module = chunk.modules[i];
-          processModule(module);
-        }
+    if (isWebpack5) {
+      for (const module of compilation.modules) {
+        processModule(module);
       }
-    });
+    } else {
+      compilation.chunks.forEach((chunk) => {
+        if (typeof chunk.modulesIterable !== "undefined") { // webpack 4
+          for (const module of chunk.modulesIterable) {
+            processModule(module);
+          }
+        } else if (typeof chunk.forEachModule !== "undefined") { // webpack 3
+          chunk.forEachModule((module) => {
+            processModule(module);
+          });
+        } else { // webpack 2
+          for (let i = 0; i < chunk.modules.length; i += 1) {
+            const module = chunk.modules[i];
+            processModule(module);
+          }
+        }
+      });
+    }
 
     const basePackageValues = Object.assign({}, this.basePackage);
 


### PR DESCRIPTION
This is a workaround for issue #27 for me,
but it checks all compilation.modules instead of getting them from the compilation.chunks, so it might not be a good final solution?
Here webpack5 after this patch:
https://pastebin.com/F3RZcWJM
In comparison to webpack4:
https://pastebin.com/F3RA9K0f