### PR TITLE
fix: remove null coalescing usage to restore compat with node 12

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ function resolveModuleBasePath(moduleName, options = undefined) {
   try {
     moduleMainFilePath = require.resolve(moduleName, options);
   } catch (e) {
-    const message = e.message ?? "";
+    const message = e.message ? e.message : "";
     const indexOfMessage = message.lastIndexOf(searchErrorNoExportsPart);
     const indexOfPackage = message.lastIndexOf("package.json");
 


### PR DESCRIPTION
Looks like a single `??` was added to the code in the last couple of months, which breaks compatibility with node 12. Would ya'll be open to restoring node 12 compatibility via this change?