### PR TITLE
Switched order of additionalDependencies to allow overriding

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@ GeneratePackageJsonPlugin.prototype.apply = function (compiler) {
   const computePackageJson = (compilation) => {
     const dependencyTypes = ["dependencies", "devDependencies", "peerDependencies"]
 
-    const modules = Object.assign({}, this.additionalDependencies);
+    const modules = {};
 
     const getInstalledVersionForModuleName = (moduleName, context) => {
       let modulePackageFile;
@@ -343,6 +343,8 @@ GeneratePackageJsonPlugin.prototype.apply = function (compiler) {
         }
       }
     }
+
+    Object.assign(modules, this.additionalDependencies);
 
     logIfDebug(`GPJWP: Modules to be used in generated package.json`, modules);
 


### PR DESCRIPTION
Generally using runtime dependencies is a good strategy. Unfortunately I have a single package for which I use a github repo as the version specified. In order for the package to be installed I need to override this single dependency.

Prior to my commit it was not possible.