### PR TITLE
Fix typescript declarations to work with webpack@5

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Plugin } from 'webpack';
+import { Compiler, Plugin } from 'webpack';
 
 declare class GeneratePackageJsonPlugin extends Plugin {
   constructor(
@@ -16,6 +16,7 @@ declare class GeneratePackageJsonPlugin extends Plugin {
       excludeDependencies?: string[];
     },
   );
+  apply(compiler: Compiler): void;
 }
 
 export = GeneratePackageJsonPlugin;


### PR DESCRIPTION
Fix issue:
> TS2322: Type 'GeneratePackageJsonPlugin' is not assignable to type '((this: Compiler, compiler: Compiler) => void) | WebpackPluginInstance'.

- webpack@5 has its own ts-declaraions (no need for @types/webpack)
- `Plugin` is not exported from `webpack` in webpack@5 (is it `WebpackPluginInstance` now?)

Though it is possible to remove `@types/webpack` from the `package.json` and change parent class to  `WebpackPluginInstance` it will break compatibility with webpack@4.

With this change plugin works with both webpack@4 and webpack@5